### PR TITLE
Update to support new CDS API

### DIFF
--- a/era5/era5_level.py
+++ b/era5/era5_level.py
@@ -2,43 +2,43 @@ import cdsapi
 
 c = cdsapi.Client()
 
-c.retrieve(
-    'reanalysis-era5-pressure-levels',
-    {
-        'product_type': 'reanalysis',
-        'variable': [
-            'geopotential', 'relative_humidity', 'specific_humidity',
-            'temperature', 'u_component_of_wind', 'v_component_of_wind',
-        ],
-        'pressure_level': [
-            '1', '2', '3',
-            '5', '7', '10',
-            '20', '30', '50',
-            '70', '100', '125',
-            '150', '175', '200',
-            '225', '250', '300',
-            '350', '400', '450',
-            '500', '550', '600',
-            '650', '700', '750',
-            '775', '800', '825',
-            '850', '875', '900',
-            '925', '950', '975',
-            '1000',
-        ],
-        'year': '2022',
-        'month': '03',
-        'day': [
-            '13', '14', '15',
-        ],
-        'time': [
-            '00:00', '03:00', '06:00',
-            '09:00', '12:00', '15:00',
-            '18:00', '21:00',
-        ],
-        'area': [
-            45, 35, 20,
-            70, #North, West, South, East
-        ],
-        'format': 'grib',
-    },
-    'level.grib')
+dataset = "reanalysis-era5-pressure-levels"
+request = {
+    "product_type": ["reanalysis"],
+    "variable": [
+        "geopotential",
+        "relative_humidity",
+        "specific_humidity",
+        "temperature",
+        "u_component_of_wind",
+        "v_component_of_wind"
+    ],
+    "year": ["2022"],
+    "month": ["03"],
+    "day": ["13", "14", "15"],
+    "time": [
+        "00:00", "03:00", "06:00",
+        "09:00", "12:00", "15:00",
+        "18:00", "21:00"
+    ],
+    "pressure_level": [
+        "1", "2", "3",
+        "5", "7", "10",
+        "20", "30", "50",
+        "70", "100", "125",
+        "150", "175", "200",
+        "225", "250", "300",
+        "350", "400", "450",
+        "500", "550", "600",
+        "650", "700", "750",
+        "775", "800", "825",
+        "850", "875", "900",
+        "925", "950", "975",
+        "1000"
+    ],
+    "data_format": "grib",
+    "download_format": "unarchived",
+    "area": [45, 35, 20, 70] #North, West, South, East
+}
+
+c.retrieve(dataset, request).download()

--- a/era5/era5_level.py
+++ b/era5/era5_level.py
@@ -42,4 +42,4 @@ request = {
 }
 target = "level.grib"
 
-c.retrieve(dataset, request, target).download()
+c.retrieve(dataset, request, target)

--- a/era5/era5_level.py
+++ b/era5/era5_level.py
@@ -40,5 +40,6 @@ request = {
     "download_format": "unarchived",
     "area": [45, 35, 20, 70] #North, West, South, East
 }
+target = "level.grib"
 
-c.retrieve(dataset, request).download()
+c.retrieve(dataset, request, target).download()

--- a/era5/era5_surface.py
+++ b/era5/era5_surface.py
@@ -2,35 +2,52 @@ import cdsapi
 
 c = cdsapi.Client()
 
-c.retrieve(
-    'reanalysis-era5-single-levels',
-    {
-        'product_type': 'reanalysis',
-        'variable': [
-            '10m_u_component_of_wind', '10m_v_component_of_wind', '2m_dewpoint_temperature',
-            '2m_temperature', 'geopotential', 'land_sea_mask',
-            'leaf_area_index_high_vegetation', 'mean_sea_level_pressure', 'sea_ice_cover',
-            'sea_surface_temperature', 'snow_depth', 'soil_temperature_level_1',
-            'soil_temperature_level_2', 'soil_temperature_level_3', 'soil_temperature_level_4',
-            'soil_type', 'surface_latent_heat_flux', 'surface_pressure',
-            'top_net_solar_radiation_clear_sky', 'total_precipitation', 'volumetric_soil_water_layer_1',
-            'volumetric_soil_water_layer_2', 'volumetric_soil_water_layer_3', 'volumetric_soil_water_layer_4',
-            'skin_temperature',
-        ],
-        'year': '2022',
-        'month': '03',
-        'day': [
-            '13', '14', '15',
-        ],
-        'time': [
-            '00:00', '03:00', '06:00',
-            '09:00', '12:00', '15:00',
-            '18:00', '21:00',
-        ],
-        'area': [
-            45, 35, 20,
-            70, #North, West, South, East
-        ],
-        'format': 'grib',
-    },
-    'single.grib')
+dataset = "reanalysis-era5-single-levels"
+request = {
+    "product_type": ["reanalysis"],
+    "variable": [
+        "10m_u_component_of_wind",
+        "10m_v_component_of_wind",
+        "2m_dewpoint_temperature",
+        "2m_temperature",
+        "mean_sea_level_pressure",
+        "sea_surface_temperature",
+        "surface_pressure",
+        "total_precipitation",
+        "skin_temperature",
+        "surface_latent_heat_flux",
+        "top_net_solar_radiation_clear_sky",
+        "snow_depth",
+        "soil_temperature_level_1",
+        "soil_temperature_level_2",
+        "soil_temperature_level_3",
+        "soil_temperature_level_4",
+        "soil_type",
+        "volumetric_soil_water_layer_1",
+        "volumetric_soil_water_layer_2",
+        "volumetric_soil_water_layer_3",
+        "volumetric_soil_water_layer_4",
+        "leaf_area_index_high_vegetation",
+        "geopotential",
+        "land_sea_mask",
+        "sea_ice_cover"
+    ],
+    "year": ["2022"],
+    "month": ["03"],
+    'day': [
+        '13', '14', '15',
+    ],
+    'time': [
+        '00:00', '03:00', '06:00',
+        '09:00', '12:00', '15:00',
+        '18:00', '21:00',
+    ],
+    "data_format": "grib",
+    "download_format": "unarchived",
+    'area': [
+        45, 35, 20,
+        70, #North, West, South, East
+    ],
+}
+
+c.retrieve(dataset, request).download()

--- a/era5/era5_surface.py
+++ b/era5/era5_surface.py
@@ -49,5 +49,6 @@ request = {
         70, #North, West, South, East
     ],
 }
+target = "single.grib"
 
-c.retrieve(dataset, request).download()
+c.retrieve(dataset, request, target).download()

--- a/era5/era5_surface.py
+++ b/era5/era5_surface.py
@@ -51,4 +51,4 @@ request = {
 }
 target = "single.grib"
 
-c.retrieve(dataset, request, target).download()
+c.retrieve(dataset, request, target)


### PR DESCRIPTION
Updated the CDSAPI request in the `era5` directory for compatibility with the new API rolled out in 2024.

**Known issues**:
Geographical area selection does not work here - would download the whole available area instead. I believe this is more of a issue from the CDS datastore since when I use the web version of request form, the issue persists.